### PR TITLE
ML-502 Add sendRollbarMessage decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ Custom options:
 
 The plugin uses the standard [Person Tracking](https://docs.rollbar.com/docs/person-tracking) features. To ensure you are passing the correct info to Rollbar, place the data you want to track in the `request.auth.credentials` object. This will be copied to `request.rollbar_person` when pushing the exception to Rollbar.
 
+### Send Custom Message
+
+You can send custom messages to Rollbar via the `request.sendRollbarMessage` decorator. It will default to the `error` level. You use any Rollbar supported level:
+
+```
+debug
+info
+warning
+error
+critical
+```
+
+Example call:
+
+```js
+request.sendRollbarMessage({
+    level: 'warning', // defaults to 'error'
+    message: 'Custom Message'
+})
+```
+
 ## Running Tests
 
 To run tests, just run the following:

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,9 +24,14 @@ exports.register = (server, options) => {
         // Inject Person Tracking data
         this.rollbar_person = this.auth.credentials;
 
+        rollbarClient.error(message, this, (err) => {
+            console.log('HERE', err)
+        })
+
         return await rollbarClient[level](message, this, (err) => {
             if (err) {
                 this.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
+                return false;
             }
         });
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,14 +24,9 @@ exports.register = (server, options) => {
         // Inject Person Tracking data
         this.rollbar_person = this.auth.credentials;
 
-        rollbarClient.error(message, this, (err) => {
-            console.log('HERE', err)
-        })
-
         return await rollbarClient[level](message, this, (err) => {
             if (err) {
                 this.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
-                return false;
             }
         });
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,15 +24,11 @@ exports.register = (server, options) => {
         // Inject Person Tracking data
         this.rollbar_person = this.auth.credentials;
 
-        const cb = function cb(err) {
+        return await rollbarClient[level](message, this, (err) => {
             if (err) {
                 this.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
-                return false;
             }
-            return true;
-        };
-
-        return await rollbarClient[level](message, this, cb);
+        });
     };
 
     // Add helper method to request
@@ -46,16 +42,14 @@ exports.register = (server, options) => {
         const shouldHandleError = isError && omittedResponseCodes.indexOf(status) === -1;
 
         if (shouldHandleError) {
-            const cb = (err) => {
-                if (err) {
-                    request.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
-                }
-            };
-
             // Inject Person Tracking data
             request.rollbar_person = request.auth.credentials;
 
-            await rollbarClient.error(request.response, request, cb);
+            await rollbarClient.error(request.response, request, (err) => {
+                if (err) {
+                    request.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
+                }
+            });
 
             return h.continue;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,42 @@
 const Rollbar = require('rollbar');
 
+const validLevels = [
+    'debug',
+    'info',
+    'warning',
+    'error',
+    'critical'
+];
+
 exports.register = (server, options) => {
     const rollbarClient = options.rollbarClient || new Rollbar(options);
     rollbarClient.omittedResponseCodes = options.omittedResponseCodes || [];
 
+    // Add Rollbar client to server
     server.decorate('server', 'rollbar', rollbarClient);
+
+    const sendRollbarMessage = async function sendRollbarMessage({ level = 'error', message }) {
+        if (validLevels.indexOf(level) === -1) {
+            this.log(['rollbar', 'error'], `Invalid level provided: ${level}. Must be one of [${validLevels.join(', ')}]`);
+            return false;
+        }
+
+        // Inject Person Tracking data
+        this.rollbar_person = this.auth.credentials;
+
+        const cb = function cb(err) {
+            if (err) {
+                this.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
+                return false;
+            }
+            return true;
+        };
+
+        return await rollbarClient[level](message, this, cb);
+    };
+
+    // Add helper method to request
+    server.decorate('request', 'sendRollbarMessage', sendRollbarMessage);
 
     server.ext('onPreResponse', async (request, h) => {
         const response = request.response;
@@ -14,12 +46,13 @@ exports.register = (server, options) => {
         const shouldHandleError = isError && omittedResponseCodes.indexOf(status) === -1;
 
         if (shouldHandleError) {
-            const cb = (rollbarErr) => {
-                if (rollbarErr) {
-                    request.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${rollbarErr}`);
+            const cb = (err) => {
+                if (err) {
+                    request.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
                 }
             };
 
+            // Inject Person Tracking data
             request.rollbar_person = request.auth.credentials;
 
             await rollbarClient.error(request.response, request, cb);

--- a/spec/hapi-rollbar.spec.js
+++ b/spec/hapi-rollbar.spec.js
@@ -32,7 +32,7 @@ describe('lib-hapi-rollbar plugin tests', () => {
             server.route({ method: 'GET',
                 path: '/sendCustomMessage',
                 handler: async (request) => {
-                    await request.sendRollbarMessage({ level: 'info', request, message: 'test message' });
+                    await request.sendRollbarMessage({ level: 'info', message: 'test message' });
 
                     return true;
                 } });
@@ -40,7 +40,7 @@ describe('lib-hapi-rollbar plugin tests', () => {
             server.route({ method: 'GET',
                 path: '/sendErrorMessage',
                 handler: async (request) => {
-                    await request.sendRollbarMessage({ request, message: 'test error message' });
+                    await request.sendRollbarMessage({ message: 'test error message' });
 
                     return true;
                 } });
@@ -48,7 +48,7 @@ describe('lib-hapi-rollbar plugin tests', () => {
             server.route({ method: 'GET',
                 path: '/sendInvalidMessage',
                 handler: async (request) => {
-                    await request.sendRollbarMessage({ level: 'bad', request, message: 'test bad message' });
+                    await request.sendRollbarMessage({ level: 'bad', message: 'test bad message' });
 
                     return true;
                 } });
@@ -87,12 +87,18 @@ describe('lib-hapi-rollbar plugin tests', () => {
             await server.inject('/sendCustomMessage');
             expect(mockRollbarClient.error).not.toHaveBeenCalled();
             expect(mockRollbarClient.info).toHaveBeenCalled();
+            // Check that the `this` is a request object
+            const args = mockRollbarClient.info.calls.argsFor(0);
+            expect(args[1].path).toBe('/sendCustomMessage');
         });
 
         it('should add a message helper method to the server [default case]', async () => {
             await server.inject('/sendErrorMessage');
             expect(mockRollbarClient.error).toHaveBeenCalled();
             expect(mockRollbarClient.info).not.toHaveBeenCalled();
+            // Check that the `this` is a request object
+            const args = mockRollbarClient.error.calls.argsFor(0);
+            expect(args[1].path).toBe('/sendErrorMessage');
         });
 
         it('should add a message helper method to the server [error case]', async () => {


### PR DESCRIPTION
- Added `sendRollbarMessage` decorator to the `request` object.
- This allows the sending of custom messages to Rollbar within a Hapi `request` handler.

```js
request.sendRollbarMessage({
    level: 'warning', // defaults to 'error'
    message: 'Custom Message'
})
```