### PR TITLE
ML-502 Added payload to message sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ if (process.env.ROLLBAR_TOKEN && ['production', 'staging'].indexOf(process.env.N
             codeVersion: require('../package.json').version // eslint-disable-line global-require
         }
     });
+} else {
+    // passthru helper method to clean up code when rollbar is not configured
+    server.decorate('request', 'sendRollbarMessage', () => {});
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ Example call:
 ```js
 request.sendRollbarMessage({
     level: 'warning', // defaults to 'error'
-    message: 'Custom Message'
+    message: 'Custom Message',
+    payload: { custom: { payload: 'data' } }
 })
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ exports.register = (server, options) => {
     // Add Rollbar client to server
     server.decorate('server', 'rollbar', rollbarClient);
 
-    const sendRollbarMessage = async function sendRollbarMessage({ level = 'error', message }) {
+    const sendRollbarMessage = async function sendRollbarMessage({ level = 'error', message, payload }) {
         if (validLevels.indexOf(level) === -1) {
             this.log(['rollbar', 'error'], `Invalid level provided: ${level}. Must be one of [${validLevels.join(', ')}]`);
             return false;
@@ -24,7 +24,7 @@ exports.register = (server, options) => {
         // Inject Person Tracking data
         this.rollbar_person = this.auth.credentials;
 
-        return await rollbarClient[level](message, this, (err) => {
+        return await rollbarClient[level](message, payload, this, (err) => {
             if (err) {
                 this.log(['rollbar', 'error'], `Error reporting to rollbar, ignoring: ${err}`);
             }

--- a/spec/hapi-rollbar.spec.js
+++ b/spec/hapi-rollbar.spec.js
@@ -33,7 +33,11 @@ describe('lib-hapi-rollbar plugin tests', () => {
             server.route({ method: 'GET',
                 path: '/sendCustomMessage',
                 handler: async (request) => {
-                    await request.sendRollbarMessage({ level: 'info', message: 'test message' });
+                    await request.sendRollbarMessage({
+                        level: 'info',
+                        message: 'test message',
+                        payload: { test: 'payload' }
+                    });
 
                     return true;
                 } });
@@ -90,7 +94,8 @@ describe('lib-hapi-rollbar plugin tests', () => {
             expect(mockRollbarClient.info).toHaveBeenCalled();
             // Check that the `this` is a request object
             const args = mockRollbarClient.info.calls.argsFor(0);
-            expect(args[1].path).toBe('/sendCustomMessage');
+            expect(args[2].path).toBe('/sendCustomMessage');
+            expect(args[1]).toEqual({ test: 'payload' });
         });
 
         it('should add a message helper method to the server [default case]', async () => {
@@ -99,7 +104,7 @@ describe('lib-hapi-rollbar plugin tests', () => {
             expect(mockRollbarClient.info).not.toHaveBeenCalled();
             // Check that the `this` is a request object
             const args = mockRollbarClient.error.calls.argsFor(0);
-            expect(args[1].path).toBe('/sendErrorMessage');
+            expect(args[2].path).toBe('/sendErrorMessage');
         });
 
         it('should add a message helper method to the server [error case]', async () => {


### PR DESCRIPTION
After re-reading the [docs](https://docs.rollbar.com/docs/server) on how to use the logging methods, I realized we should pass a `message` and a `payload` when pushing to Rollbar.

```js
request.sendRollbarMessage({
    level: 'warning', // defaults to 'error'
    message: 'Custom Message',
    payload: { custom: { payload: 'data' } }
})
```